### PR TITLE
Added the possibility to define more than one Pushover & Telegram notifiers

### DIFF
--- a/cmd/monitor/config/example/credentials.toml
+++ b/cmd/monitor/config/example/credentials.toml
@@ -1,6 +1,11 @@
 [Pushover]
     Token=""
     UserKey=""
+#   to add more pushover notifiers, uncomment and use the example below
+#   Additional = [
+#       { Token = "token P2", UserKey = "userKey P2"},
+#       { Token = "token P3", UserKey = "userKey P3"},
+#   ]
 
 [Smtp]
     Email="from@email.com"
@@ -9,3 +14,8 @@
 [Telegram]
     Token=""
     ChatID=""
+#   to add more telegram notifiers, uncomment and use the example below
+#   Additional = [
+#       { Token = "token T2", ChatID = "chatID T2"},
+#       { Token = "token T3", ChatID = "chatID T3"},
+#   ]

--- a/config/credentialsConfig.go
+++ b/config/credentialsConfig.go
@@ -7,10 +7,22 @@ type CredentialsConfig struct {
 	Telegram TelegramCredentialsConfig
 }
 
-// PushoverCredentialsConfig defines the Pushover service credentials
-type PushoverCredentialsConfig struct {
+// TokenUserKeyConfig defines a struct that contains one token and one user key
+type TokenUserKeyConfig struct {
 	Token   string
 	UserKey string
+}
+
+// TokenChatIDConfig defines a struct that contains one token and one chat ID
+type TokenChatIDConfig struct {
+	Token  string
+	ChatID string
+}
+
+// PushoverCredentialsConfig defines the Pushover service credentials
+type PushoverCredentialsConfig struct {
+	TokenUserKeyConfig
+	Additional []TokenUserKeyConfig
 }
 
 // EmailPasswordConfig defines an email-password credential
@@ -21,6 +33,6 @@ type EmailPasswordConfig struct {
 
 // TelegramCredentialsConfig defines the Telegram service credentials
 type TelegramCredentialsConfig struct {
-	Token  string
-	ChatID string
+	TokenChatIDConfig
+	Additional []TokenChatIDConfig
 }

--- a/config/tomlConfig_test.go
+++ b/config/tomlConfig_test.go
@@ -134,30 +134,62 @@ func TestLoadCredentialsConfig(t *testing.T) {
 
 	testString := `
 [Pushover]
-    Token="token1"
-    UserKey="userKey1"
+    Token="token P1"
+    UserKey="userKey P1"
+    Additional = [
+        { Token = "token P2", UserKey = "userKey P2"},
+        { Token = "token P3", UserKey = "userKey P3"},
+    ]
 
 [Smtp]
     Email="from@email.com"
     Password="password"
 
 [Telegram]
-    Token="token2"
-    ChatID="chat_id2"
+    Token="token T1"
+    ChatID="chatID T1"
+    Additional = [
+        { Token = "token T2", ChatID = "chatID T2"},
+        { Token = "token T3", ChatID = "chatID T3"},
+    ]
 `
 
 	expectedCfg := CredentialsConfig{
 		Pushover: PushoverCredentialsConfig{
-			Token:   "token1",
-			UserKey: "userKey1",
+			TokenUserKeyConfig: TokenUserKeyConfig{
+				Token:   "token P1",
+				UserKey: "userKey P1",
+			},
+			Additional: []TokenUserKeyConfig{
+				{
+					Token:   "token P2",
+					UserKey: "userKey P2",
+				},
+				{
+					Token:   "token P3",
+					UserKey: "userKey P3",
+				},
+			},
 		},
 		Smtp: EmailPasswordConfig{
 			Email:    "from@email.com",
 			Password: "password",
 		},
 		Telegram: TelegramCredentialsConfig{
-			Token:  "token2",
-			ChatID: "chat_id2",
+			TokenChatIDConfig: TokenChatIDConfig{
+				Token:  "token T1",
+				ChatID: "chatID T1",
+			},
+			Additional: []TokenChatIDConfig{
+				{
+					Token:  "token T2",
+					ChatID: "chatID T2",
+				},
+				{
+					Token:  "token T3",
+					ChatID: "chatID T3",
+				},
+			},
 		},
 	}
 

--- a/factory/notifiersFactory_test.go
+++ b/factory/notifiersFactory_test.go
@@ -34,6 +34,42 @@ func TestCreateOutputNotifiers(t *testing.T) {
 		assert.Equal(t, "*notifiers.logNotifier", fmt.Sprintf("%T", notifiers[0]))
 		assert.Equal(t, "*notifiers.pushoverNotifier", fmt.Sprintf("%T", notifiers[1]))
 	})
+	t.Run("should create 3 pushover notifiers and a log notifier", func(t *testing.T) {
+		notifiers, err := CreateOutputNotifiers(config.AllConfigs{
+			Config: config.MainConfig{
+				OutputNotifiers: config.OutputNotifiersConfig{
+					Pushover: config.PushoverNotifierConfig{
+						Enabled: true,
+					},
+				},
+			},
+			Credentials: config.CredentialsConfig{
+				Pushover: config.PushoverCredentialsConfig{
+					TokenUserKeyConfig: config.TokenUserKeyConfig{
+						Token:   "token1",
+						UserKey: "userKey1",
+					},
+					Additional: []config.TokenUserKeyConfig{
+						{
+							Token:   "token2",
+							UserKey: "userKey2",
+						},
+						{
+							Token:   "token3",
+							UserKey: "userKey3",
+						},
+					},
+				},
+			},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, 4, len(notifiers)) // 1 log + 3 pushover
+		assert.Equal(t, "*notifiers.logNotifier", fmt.Sprintf("%T", notifiers[0]))
+		assert.Equal(t, "*notifiers.pushoverNotifier", fmt.Sprintf("%T", notifiers[1]))
+		assert.Equal(t, "*notifiers.pushoverNotifier", fmt.Sprintf("%T", notifiers[2]))
+		assert.Equal(t, "*notifiers.pushoverNotifier", fmt.Sprintf("%T", notifiers[3]))
+	})
 	t.Run("should create a smtp and a log notifier", func(t *testing.T) {
 		notifiers, err := CreateOutputNotifiers(config.AllConfigs{
 			Config: config.MainConfig{
@@ -65,5 +101,41 @@ func TestCreateOutputNotifiers(t *testing.T) {
 		assert.Equal(t, 2, len(notifiers))
 		assert.Equal(t, "*notifiers.logNotifier", fmt.Sprintf("%T", notifiers[0]))
 		assert.Equal(t, "*notifiers.telegramNotifier", fmt.Sprintf("%T", notifiers[1]))
+	})
+	t.Run("should create 3 telegram notifiers and a log notifier", func(t *testing.T) {
+		notifiers, err := CreateOutputNotifiers(config.AllConfigs{
+			Config: config.MainConfig{
+				OutputNotifiers: config.OutputNotifiersConfig{
+					Telegram: config.TelegramNotifierConfig{
+						Enabled: true,
+					},
+				},
+			},
+			Credentials: config.CredentialsConfig{
+				Telegram: config.TelegramCredentialsConfig{
+					TokenChatIDConfig: config.TokenChatIDConfig{
+						Token:  "token1",
+						ChatID: "chatID1",
+					},
+					Additional: []config.TokenChatIDConfig{
+						{
+							Token:  "token2",
+							ChatID: "chatID2",
+						},
+						{
+							Token:  "token3",
+							ChatID: "chatID3",
+						},
+					},
+				},
+			},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, 4, len(notifiers)) // 1 log + 3 telegram
+		assert.Equal(t, "*notifiers.logNotifier", fmt.Sprintf("%T", notifiers[0]))
+		assert.Equal(t, "*notifiers.telegramNotifier", fmt.Sprintf("%T", notifiers[1]))
+		assert.Equal(t, "*notifiers.telegramNotifier", fmt.Sprintf("%T", notifiers[2]))
+		assert.Equal(t, "*notifiers.telegramNotifier", fmt.Sprintf("%T", notifiers[3]))
 	})
 }


### PR DESCRIPTION
- added the possibility to define more than one Pushover & Telegram notifiers

Solves this issue: https://github.com/multiversx/mx-chain-keys-monitor-go/issues/21